### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -26,7 +26,7 @@ class action_plugin_lastfm extends DokuWiki_Action_Plugin{
                 );
     }
 
-    function register(&$contr) {
+    function register(Doku_Event_Handler $contr) {
         $contr->register_hook('AJAX_CALL_UNKNOWN', 'BEFORE', $this, 'handle_ajax_call', array());
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -77,7 +77,7 @@ class syntax_plugin_lastfm extends DokuWiki_Syntax_Plugin {
     /**
      * Handler to prepare matched data for the rendering process
      */
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
         $data   = array();
         $charts = array('topartists', 'topalbums', 'toptracks', 'tags', 'friends',
@@ -116,7 +116,7 @@ class syntax_plugin_lastfm extends DokuWiki_Syntax_Plugin {
     /**
      * Handles the actual output creation.
      */
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         global $ID;
         global $lang;
 


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
